### PR TITLE
chore: replace dead ubuntu 23.04 by ubuntu 24.04 as build env

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.04 as mingw
+FROM ubuntu:24.04 as mingw
 
 RUN dpkg --add-architecture i386
 RUN \

--- a/docker/clang-cl-msvc.Dockerfile
+++ b/docker/clang-cl-msvc.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.04 as msvc-wine
+FROM ubuntu:24.04 as msvc-wine
 
 RUN apt-get update && \
     apt-get install -y wine64-development python3 msitools python3-simplejson git \


### PR DESCRIPTION
I don't know if everything works in the new environment; I've only successfully built the library by `./scripts/tools.sh docker-build` .

https://endoflife.date/ubuntu