### PR TITLE
docs: use "docker compose" instead of "docker-compose"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For convenience, a Docker image is provided for both MinGW and clang-cl toolchai
 Build the images:
 
 ```bash
-docker-compose build builder
+docker compose build builder
 ```
 
 Build the library with docker:
@@ -81,8 +81,8 @@ If you built the main docker image then protobuf has already been built and you 
 
 ```bash
 mkdir -p opt/usr
-docker-compose cp -L builder:/usr/i686-w64-mingw32 opt/usr
-docker-compose cp -L builder:/usr/bin/protoc opt/bin
+docker compose cp -L builder:/usr/i686-w64-mingw32 opt/usr
+docker compose cp -L builder:/usr/bin/protoc opt/bin
 ```
 
 #### Build

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -17,7 +17,7 @@ GDB_COMMAND='gdb'
 
 function dcmd_generic() {
 	: ${user:="root"}
-	docker-compose -f docker-compose.yml exec --user "$user" \
+	docker compose -f docker-compose.yml exec --user "$user" \
 		-w "$HOMEDIR"/build_docker \
 		$BUILDER bash -c "$1"
 }
@@ -71,9 +71,9 @@ function debug_testcase() {
 	fi
 	export UID=$(id -u)
 	export GID=$(id -g)
-	docker-compose down --remove-orphans -t 1
+	docker compose down --remove-orphans -t 1
 
-	COMMAND="$WINE_CMD $EXE" docker-compose up $CARGS vnc "$BUILDER"
+	COMMAND="$WINE_CMD $EXE" docker compose up $CARGS vnc "$BUILDER"
 	if [[ "$CARGS" == "-d" ]]; then
 		sleep 2
 		P='x86_64-w64-mingw32-gdb -ex "set solib-search-path "'"$HOMEDIR/$BUILDDIR/$TOOLCHAIN"'/pkg/bin"" -ex "target extended-remote '"$TARGET"'" --args '"$EXE"
@@ -84,8 +84,8 @@ function debug_testcase() {
 function docker_run() {
 	export UID=$(id -u)
 	export GID=$(id -g)
-	docker-compose down --remove-orphans -t 1
-	docker-compose run --rm -it $BUILDER $EXE
+	docker compose down --remove-orphans -t 1
+	docker compose run --rm -it $BUILDER $EXE
 }
 
 # x86_64-w64-mingw32-gdb myprogram.exe
@@ -99,4 +99,4 @@ $DEBUG_FN
 # gdb_connect
 # dcmd_gen "$@"
 
-# COMMAND="sh -c 'BUILDDIR=$(BUILDDIR) make BUILDDIR=$(BUILDDIR) DEST_DIR=$(DEST_DIR) TESTS=$$f test'" docker-compose up --abort-on-container-exit vnc builder; done
+# COMMAND="sh -c 'BUILDDIR=$(BUILDDIR) make BUILDDIR=$(BUILDDIR) DEST_DIR=$(DEST_DIR) TESTS=$$f test'" docker compose up --abort-on-container-exit vnc builder; done


### PR DESCRIPTION
Hi.

Commit message:

```
We have Compose V2: https://docs.docker.com/compose/releases/migrate/#docker-compose-vs-docker-compose

On normal installtion of Docker, there is no "docker-compose" executable.

```

Output:

```console
# docker -v
Docker version 27.5.1, build 9f9e405
# docker compose version
Docker Compose version v2.32.4
# docker-compose
Command 'docker-compose' not found, but can be installed with:
snap install docker          # version 27.4.1, or
apt  install docker-compose  # version 1.29.2-6.3
See 'snap info docker' for additional versions.

```

Merge this if `docker compose` is supported on your machine.

.
