### PR TITLE
fix: remove "version" from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   builder:
     image: shmocz/ra2yrcpp:latest


### PR DESCRIPTION
https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete

```
WARN[0000] .../ra2yrcpp/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion    

```