### PR TITLE
docs: "docker compose cp -L" does not dereference symlinks in directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If you built the main docker image then protobuf has already been built and you 
 
 ```bash
 mkdir -p opt/usr
-docker compose cp -L builder:/usr/i686-w64-mingw32 opt/usr
+docker compose exec builder tar -C /usr -c --dereference i686-w64-mingw32 | tar -C opt/usr -x
 docker compose cp -L builder:/usr/bin/protoc opt/bin
 ```
 


### PR DESCRIPTION
Hi!

Before:

```
$ ls -g -o ./opt/usr/i686-w64-mingw32/bin/
total 14452
lrwxrwxrwx 1       29 Jan 25  2024 ar -> ../../bin/i686-w64-mingw32-ar
lrwxrwxrwx 1       29 Jan 25  2024 as -> ../../bin/i686-w64-mingw32-as
lrwxrwxrwx 1       34 Jan 25  2024 dlltool -> ../../bin/i686-w64-mingw32-dlltool
lrwxrwxrwx 1       29 Jan 25  2024 ld -> ../../bin/i686-w64-mingw32-ld
lrwxrwxrwx 1       29 Jan 25  2024 ld.bfd -> ../../bin/i686-w64-mingw32-ld
lrwxrwxrwx 1       29 Jan 25  2024 nm -> ../../bin/i686-w64-mingw32-nm
lrwxrwxrwx 1       34 Jan 25  2024 objcopy -> ../../bin/i686-w64-mingw32-objcopy
lrwxrwxrwx 1       34 Jan 25  2024 objdump -> ../../bin/i686-w64-mingw32-objdump
lrwxrwxrwx 1       20 Dec 27 18:12 protoc.exe -> protoc.exe-3.21.12.0
-rwxr-xr-x 1 14797564 Dec 27 18:12 protoc.exe-3.21.12.0
lrwxrwxrwx 1       33 Jan 25  2024 ranlib -> ../../bin/i686-w64-mingw32-ranlib
lrwxrwxrwx 1       34 Jan 25  2024 readelf -> ../../bin/i686-w64-mingw32-readelf
lrwxrwxrwx 1       32 Jan 25  2024 strip -> ../../bin/i686-w64-mingw32-strip

```

After:

```
$ ls -g -o ./opt/usr/i686-w64-mingw32/bin/
total 44776
-rwxr-xr-x 1  1164680 Jan 25  2024 ar
-rwxr-xr-x 1  1805360 Jan 25  2024 as
-rwxr-xr-x 1  1201736 Jan 25  2024 dlltool
-rwxr-xr-x 2  1752048 Jan 25  2024 ld
-rwxr-xr-x 2  1752048 Jan 25  2024 ld.bfd
-rwxr-xr-x 1  1157440 Jan 25  2024 nm
-rwxr-xr-x 1  1283528 Jan 25  2024 objcopy
-rwxr-xr-x 1  2642464 Jan 25  2024 objdump
-rwxr-xr-x 2 14797564 Dec 27 18:12 protoc.exe
-rwxr-xr-x 2 14797564 Dec 27 18:12 protoc.exe-3.21.12.0
-rwxr-xr-x 1  1164712 Jan 25  2024 ranlib
-rwxr-xr-x 1  1022864 Jan 25  2024 readelf
-rwxr-xr-x 1  1283528 Jan 25  2024 strip

```

Ref:

- https://github.com/moby/moby/issues/30213